### PR TITLE
Fixed version regex to support versions with letters

### DIFF
--- a/utils/util.js
+++ b/utils/util.js
@@ -92,7 +92,7 @@ module.exports.determineSandboxVersion = function (sbox) {
     sbox = sbox || global.settings.value("sandboxes." + global.settings.value("defaults.sandbox"));
     if (!sbox) return null;
     let sandboxVersionFile = fs.readFileSync(sbox.path + "/version.txt");
-    let sandboxVersion = /([\d\.]*)-.*/.exec(sandboxVersionFile)[1];
+    let sandboxVersion = /([\d\.].*?)-.*/.exec(sandboxVersionFile)[1];
     return sandboxVersion;
 }
 


### PR DESCRIPTION
Currently, it is impossible to deploy if versions contain a letter - 22.1.00A for example. This PR should fix this problem